### PR TITLE
Start of work on a BiFunctor approach and a BiFunctor implementation called Task

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/scb/support/BiFunctor.scala
+++ b/src/main/scala/uk/gov/nationalarchives/scb/support/BiFunctor.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.gov.nationalarchives.scb.support
+
+/**
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+trait BiFunctor[F[_, _]] {
+
+  def pureA[A, B](a: => A): F[A, B]
+  def pureB[A, B](b: => B): F[A, B]
+
+  // TODO(AR) consider implementing transform() instead of map() and recoverWith()
+  def bimap[A, B, AA, BB](F: F[A, B])(f: A => AA, g: B => BB): F[AA, BB]
+}

--- a/src/main/scala/uk/gov/nationalarchives/scb/support/BiFunctorAdapter.scala
+++ b/src/main/scala/uk/gov/nationalarchives/scb/support/BiFunctorAdapter.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.gov.nationalarchives.scb.support
+
+import uk.gov.nationalarchives.scb.support.task.Task
+
+/**
+ * Adapters from various Types to BiFunctors.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+object BiFunctorAdapter {
+
+  /**
+   * Adapts a Task to a BiFunctor[Task].
+   */
+  implicit val biFunctorForTask: BiFunctor[Task] = new BiFunctor[Task] {
+
+    override def pureA[A, B](a: => A): Task[A, B] = Task.applyE(() => a)
+
+    override def pureB[A, B](b: => B): Task[A, B] = Task.applyT(() => b)
+
+    override def bimap[E, T, EE, TT](F: Task[E, T])(fe: E => EE, ft: T => TT): Task[EE, TT] = {
+      F.bimap(fe, ft)
+    }
+  }
+}

--- a/src/main/scala/uk/gov/nationalarchives/scb/support/task/Task.scala
+++ b/src/main/scala/uk/gov/nationalarchives/scb/support/task/Task.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.gov.nationalarchives.scb.support.task
+
+import scala.reflect.{ClassTag, classTag}
+
+/**
+ * A general purpose Task. Unlike a Future, a Task has deferred execution,
+ * but similar to an either in that it can return an Error or a Result.
+ *
+ * @author <a href="mailto:adam@evolvedbinary.com">Adam Retter</a>
+ */
+sealed abstract trait Task[+E, +T] {
+  // TODO(AR) should we memoise the result on the first call? - could use a lazy val?
+  def compute(): TaskResult[E, T]
+  def bimap[EE, TT](fe: E => EE, ft: T => TT): Task[EE, TT]
+}
+
+class EitherTask[+E, +T](f: () => Either[E, T]) extends Task[E, T] {
+  override def compute(): TaskResult[E, T] = f().fold(TaskFailed(_), TaskSuccess(_))
+  override def bimap[EE, TT](fe: E => EE, ft: T => TT): Task[EE, TT] = {
+    new EitherTask[EE, TT](() => f().left.map(fe).map(ft))
+  }
+}
+
+// the ClassTag captures the type of E for pattern matching
+class TryETask[+E <: Throwable: ClassTag, +T](f: () => T) extends Task[E, T] {
+  override def compute(): TaskResult[E, T] = {
+    scala.util.control.Exception.handling[TaskResult[E, T]](classTag[E].runtimeClass)
+      .by(t => TaskFailed(t.asInstanceOf[E]))
+      .apply{ TaskSuccess(f()) }
+  }
+
+  override def bimap[EE, TT](fe: E => EE, ft: T => TT): Task[EE, TT] = {
+    new EitherTask[EE, TT] (
+      () =>
+        scala.util.control.Exception.catching[TT](classTag[E].runtimeClass)
+          .either{ ft(f()) }
+          .left.map(_.asInstanceOf[E])
+          .left.map(fe)
+    )
+  }
+}
+
+//  class DefaultTask[+E, +T](f: Either[() => T, () => Either[E, T]]) {
+//    def compute(): TaskResult[E, T] = {
+//      f match {
+//        case Left(l) =>
+//          try {
+//            TaskSuccess(l())
+//          } catch {
+//            case e: E =>
+//              TaskFailed(e)
+//          }
+//        case Right(r) =>
+//          r().fold(TaskFailed(_), TaskSuccess(_))
+//      }
+//    }
+//  }
+
+sealed abstract class TaskResult[+E, +T]
+sealed case class TaskSuccess[+E, +T](t: T) extends TaskResult[E, T]
+sealed case class TaskFailed[+E, +T](e: E) extends TaskResult[E, T]
+
+object Task {
+  // the ClassTag captures the type of E for pattern matching
+  def make[E <: Throwable: ClassTag, T](f: () => T): Task[E, T] = new TryETask[E, T](f)
+  def apply[E, T](f: () => Either[E, T]): Task[E, T] = new EitherTask[E, T](f)
+  def applyE[E, T](f: () => E): Task[E, T] = new EitherTask[E, T](() => Left(f()))
+  def applyT[E, T](f: () => T): Task[E, T] = new EitherTask[E, T](() => Right(f()))
+}


### PR DESCRIPTION
This is the start of a `BiFunctor` implementation, which would replace the `Functor`s in the Circuit Breakers, thus allowing us to explicitly manage the Type of errors/exceptions. We would also need to add a Functor to BiFunctor adapter to preserve the existing facilities; this would allow the user to use either a `F[_]` or `F[_,_]` type when working with the Circuit Breakers.

This also includes a simple example implementation of a BiFunctor called `Task`.

At the moment it compiles but significant further refactoring would be required.

If it is desirable to add this to the project, we could continue this work in future...