### PR TITLE
Don't eagerly evaluate task to protect

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/scb/CircuitBreaker.scala
+++ b/src/main/scala/uk/gov/nationalarchives/scb/CircuitBreaker.scala
@@ -56,7 +56,7 @@ trait CircuitBreaker {
    *
    * @return the result of the task.
    */
-  def protect[F[_], T](task: F[T])(implicit functor: Functor[F]): ProtectedTask[F[T]]
+  def protect[F[_], T](task: => F[T])(implicit functor: Functor[F]): ProtectedTask[F[T]]
 }
 
 /**

--- a/src/main/scala/uk/gov/nationalarchives/scb/StandardCircuitBreaker.scala
+++ b/src/main/scala/uk/gov/nationalarchives/scb/StandardCircuitBreaker.scala
@@ -54,7 +54,7 @@ class StandardCircuitBreaker(val name: String, maxFailures: Int, resetTimeout: D
     listeners = listeners :+ listener
   }
 
-  override def protect[F[_], T](task: F[T])(implicit functor: Functor[F]): ProtectedTask[F[T]] = {
+  override def protect[F[_], T](task: => F[T])(implicit functor: Functor[F]): ProtectedTask[F[T]] = {
     state match {
       case CLOSED =>
         execClosedTask(task)(functor)

--- a/src/main/scala/uk/gov/nationalarchives/scb/ThreadSafeCircuitBreaker.scala
+++ b/src/main/scala/uk/gov/nationalarchives/scb/ThreadSafeCircuitBreaker.scala
@@ -56,7 +56,7 @@ class ThreadSafeCircuitBreaker(val name: String, maxFailures: Int, resetTimeout:
     listeners.add(listener)
   }
 
-  override def protect[F[_], T](task: F[T])(implicit functor: Functor[F]): ProtectedTask[F[T]] = {
+  override def protect[F[_], T](task: => F[T])(implicit functor: Functor[F]): ProtectedTask[F[T]] = {
     state.get() match {
       case CLOSED =>
         execClosedTask(task)(functor)


### PR DESCRIPTION
For eagerly evaluated types like Try or Future, defining `def protect[F[_], T](task: F[T])(...): ProtectedTask[F[T]]` is useless because the task will be run no matter the state of the circuit breaker.

Chaning the signature to `task: => F[T]` fixes the problem.

See test modified in [CircuitBreakerBeharious](src/test/scala/uk/gov/nationalarchives/scb/CircuitBreakerBehaviours.scala).

The behaviour is correct for lazily evaluated `F`s like `ZIO` or cats-io.

See also [this scastie](https://scastie.scala-lang.org/KkuUBLKSTcusuczfetKRKw) for a reproduction of the problem (and show that the problem is not there for ZIO).